### PR TITLE
Fix default waiter to real exponential backoff.

### DIFF
--- a/lib/executor.ts
+++ b/lib/executor.ts
@@ -23,7 +23,7 @@ export class Executor<T> implements ExecutorInterface<T> {
   protected static defaultMaxTries:       number       = 5;
   protected static defaultTimeout:        number       = -1;
   protected static defaultRetryCondition: HookFunction = () => true;
-  protected static defaultWaiter:         HookFunction = (tries: number) => wait(100 * tries ** 2);
+  protected static defaultWaiter:         HookFunction = (tries: number) => wait(100 * 2 ** tries);
 
   protected maxTries:       number       = Executor.defaultMaxTries;
   protected timeout:        number       = Executor.defaultTimeout;

--- a/lib/executor.ts
+++ b/lib/executor.ts
@@ -23,7 +23,7 @@ export class Executor<T> implements ExecutorInterface<T> {
   protected static defaultMaxTries:       number       = 5;
   protected static defaultTimeout:        number       = -1;
   protected static defaultRetryCondition: HookFunction = () => true;
-  protected static defaultWaiter:         HookFunction = (tries: number) => wait(100 * 2 ** tries);
+  protected static defaultWaiter:         HookFunction = (tries: number) => wait(100 * 2 ** (tries - 1));
 
   protected maxTries:       number       = Executor.defaultMaxTries;
   protected timeout:        number       = Executor.defaultTimeout;

--- a/test/executor.ts
+++ b/test/executor.ts
@@ -208,10 +208,10 @@ test("exponential backoff from 100ms by default", async t => {
 
   const endTime = Date.now();
 
-  // 1st -> 100ms -> 2nd -> 400ms -> 3rd -> 800ms -> 4th -> 1600ms -> 5th -> reject
-  // 100 + 400 + 800 + 1600 == 2900 (ms)
-  t.true(endTime - startTime > 2900);
-  t.true(endTime - startTime < 3100);
+  // 1st -> 200ms -> 2nd -> 400ms -> 3rd -> 800ms -> 4th -> 1600ms -> 5th -> reject
+  // 200 + 400 + 800 + 1600 == 3000 (ms)
+  t.true(endTime - startTime > 3000);
+  t.true(endTime - startTime < 3200);
 });
 
 test("rejects when timeout is set", async t => {

--- a/test/executor.ts
+++ b/test/executor.ts
@@ -208,10 +208,10 @@ test("exponential backoff from 100ms by default", async t => {
 
   const endTime = Date.now();
 
-  // 1st -> 200ms -> 2nd -> 400ms -> 3rd -> 800ms -> 4th -> 1600ms -> 5th -> reject
-  // 200 + 400 + 800 + 1600 == 3000 (ms)
-  t.true(endTime - startTime > 3000);
-  t.true(endTime - startTime < 3200);
+  // 1st -> 100ms -> 2nd -> 200ms -> 3rd -> 400ms -> 4th -> 800ms -> 5th -> reject
+  // 100 + 200 + 400 + 800 == 1500 (ms)
+  t.true(endTime - startTime > 1500);
+  t.true(endTime - startTime < 1700);
 });
 
 test("rejects when timeout is set", async t => {

--- a/test/executor.ts
+++ b/test/executor.ts
@@ -208,10 +208,10 @@ test("exponential backoff from 100ms by default", async t => {
 
   const endTime = Date.now();
 
-  // 1st -> 100ms -> 2nd -> 400ms -> 3rd -> 900ms -> 4th -> 1600ms -> 5th -> reject
-  // 100 + 400 + 900 + 1600 == 3000 (ms)
-  t.true(endTime - startTime > 3000);
-  t.true(endTime - startTime < 3200);
+  // 1st -> 100ms -> 2nd -> 400ms -> 3rd -> 800ms -> 4th -> 1600ms -> 5th -> reject
+  // 100 + 400 + 800 + 1600 == 2900 (ms)
+  t.true(endTime - startTime > 2900);
+  t.true(endTime - startTime < 3100);
 });
 
 test("rejects when timeout is set", async t => {


### PR DESCRIPTION
Hi!
I think your "exponential backoff" default waiter is implemented as "square backoff".

| try count (n) | square (n ** 2) | exponential (2 ** (n - 1)) |
|:--|:--|:--|
|  1|  1|  1|
|  2|  4|  2|
|  3|  9|  4|
|  4| 16| 8|

---

reference: AWS article and their sample Java code

Error retries and exponential backoff in AWS
https://docs.aws.amazon.com/general/latest/gr/api-retries.html

```
long waitTime = ((long) Math.pow(2, retryCount) * 100L);
```
---

Please check the PR.
Thank you!