### PR TITLE
Fix default waiter to exponential backoff.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ default: `-1`
 
 Hook function called before each retry. It's meant to return a Promise that resolves after specific duration.
 
-default: exponential backoff. 100ms, 400ms, 900ms, 1600ms and so on.
+default: exponential backoff. 200ms, 400ms, 800ms, 1600ms and so on.
 
-See [default waiter implementation](lib/executor.ts#L24). You can create custom waiter with [wait function](lib/wait.ts) for shorthand.
+See [default waiter implementation](lib/executor.ts#L26). You can create custom waiter with [wait function](lib/wait.ts) for shorthand.
 
 ##### `retryCondition`
 

--- a/lib/executor.ts
+++ b/lib/executor.ts
@@ -23,7 +23,7 @@ export class Executor<T> implements ExecutorInterface<T> {
   protected static defaultMaxTries:       number       = 5;
   protected static defaultTimeout:        number       = -1;
   protected static defaultRetryCondition: HookFunction = () => true;
-  protected static defaultWaiter:         HookFunction = (tries: number) => wait(100 * tries ** 2);
+  protected static defaultWaiter:         HookFunction = (tries: number) => wait(100 * 2 ** tries);
 
   protected maxTries:       number       = Executor.defaultMaxTries;
   protected timeout:        number       = Executor.defaultTimeout;

--- a/test/executor.ts
+++ b/test/executor.ts
@@ -208,8 +208,8 @@ test("exponential backoff from 100ms by default", async t => {
 
   const endTime = Date.now();
 
-  // 1st -> 100ms -> 2nd -> 400ms -> 3rd -> 900ms -> 4th -> 1600ms -> 5th -> reject
-  // 100 + 400 + 900 + 1600 == 3000 (ms)
+  // 1st -> 200ms -> 2nd -> 400ms -> 3rd -> 800ms -> 4th -> 1600ms -> 5th -> reject
+  // 200 + 400 + 800 + 1600 == 3000 (ms)
   t.true(endTime - startTime > 3000);
   t.true(endTime - startTime < 3200);
 });


### PR DESCRIPTION
Hi!
I think your "exponential backoff" default waiter is implemented as "square backoff".

| try count (n) | square (n ** 2) | exponential (2 ** n) |
|:--|:--|:--|
|  1|  1|  2|
|  2|  4|  4|
|  3|  9|  8|
|  4| 16| 16|

---

reference: AWS article and their sample Java code

Error retries and exponential backoff in AWS
https://docs.aws.amazon.com/general/latest/gr/api-retries.html

```
long waitTime = ((long) Math.pow(2, retryCount) * 100L);
```
---

Thank you!